### PR TITLE
Major Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ You can check a Player's squad by calling this function:
 -- Available both on SERVER and CLIENT.
 -- Will be -1 if this player is not in a squad.
 local id = Player:GetSquadID()
+```
 
--- You can use this function to get the squad instance.
+You can use this function to get a specific squad instance:
+
+```lua
 local squad = SquadMenu:GetSquad( id )
 
 --[[
@@ -32,12 +35,14 @@ local squad = SquadMenu:GetSquad( id )
     squad.enableRings   - boolean
     squad.friendlyFire  - boolean
     squad.isPublic      - boolean
-
-    squad.members - Player[]
-
-    Please do not modify squad.members directly.
-    Check out squad:AddMember and squad:RemoveMember if you need to. 
 ]]
+
+-- You can get the player entities that are part of the squad with:
+local players = squad:GetActiveMembers()
+
+-- "p" represents a player Entity or a string you can get from SquadMenu.GetPlayerId:
+squad:AddMember( p )
+squad:RemoveMember( p, reason ) -- reason is a number from SquadMenu.LEAVE_REASON_*
 ```
 
 You can also filter the squad name before it's assigned by using the `ShouldAllowSquadName` hook **on the server**.

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_squad_menu.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_squad_menu.lua
@@ -4,5 +4,5 @@ E2Helper.Descriptions["doesSquadExist(n)"] = "Returns 1 if the given ID points t
 E2Helper.Descriptions["getSquadName(n)"] = "Finds a squad by it's ID and returns the name. Returns a empty string if the squad does not exist."
 E2Helper.Descriptions["getSquadColor(n)"] = "Finds a squad by it's ID and returns the color. Returns vec(0) if the squad does not exist."
 E2Helper.Descriptions["getSquadMemberCount(n)"] = "Returns the number of members in a squad, or 0 if the squad does not exist."
-E2Helper.Descriptions["getSquadMembers(n)"] = "Returns an array of players in the squad associated with the squad ID, or a empty array if the squad does not exist."
+E2Helper.Descriptions["getSquadMembers(n)"] = "Returns an array of active players associated with the squad ID, or a empty array if the squad does not exist."
 E2Helper.Descriptions["getAllSquadIDs()"] = "Returns an array of all available squad IDs."

--- a/lua/entities/gmod_wire_expression2/core/custom/squad_menu.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/squad_menu.lua
@@ -33,21 +33,17 @@ end
 
 e2function number getSquadMemberCount( number id )
     local squad = SquadMenu:GetSquad( id )
-    return squad and #squad.members or 0
+    if not squad then return 0 end
+
+    local _, count = squad:GetActiveMembers()
+    return count
 end
 
 e2function array getSquadMembers( number id )
     local squad = SquadMenu:GetSquad( id )
     if not squad then return {} end
 
-    local members = {}
-
-    for _, ply in ipairs( squad.members ) do
-        if IsValid( ply ) then
-            members[#members + 1] = ply
-        end
-    end
-
+    local members = squad:GetActiveMembers()
     return members
 end
 

--- a/lua/squad_menu/client/config.lua
+++ b/lua/squad_menu/client/config.lua
@@ -1,0 +1,60 @@
+local Config = SquadMenu.Config or {}
+
+SquadMenu.Config = Config
+
+function Config:Reset()
+    self.showMembers = true
+    self.showRings = true
+    self.showHalos = false
+    self.enableSounds = true
+
+    self.nameDistance = 3000
+    self.haloDistance = 8000
+end
+
+function Config:Load()
+    self:Reset()
+
+    local data = file.Read( SquadMenu.DATA_FILE, "DATA" )
+    if not data then return end
+
+    data = SquadMenu.JSONToTable( data )
+
+    self.showMembers = data.showMembers == true
+    self.showRings = data.showRings == true
+    self.showHalos = data.showHalos == true
+    self.enableSounds = data.enableSounds == true
+
+    self.nameDistance = SquadMenu.ValidateNumber( data.nameDistance, 3000, 500, 50000 )
+    self.haloDistance = SquadMenu.ValidateNumber( data.haloDistance, 8000, 500, 50000 )
+end
+
+function Config:Save( immediate )
+    if not immediate then
+        -- avoid spamming the file system
+        timer.Remove( "SquadMenu.SaveConfigDelay" )
+        timer.Create( "SquadMenu.SaveConfigDelay", 0.5, 1, function()
+            self:Save( true )
+        end )
+
+        return
+    end
+
+    local path = SquadMenu.DATA_FILE
+
+    local data = SquadMenu.TableToJSON( {
+        showMembers = self.showMembers,
+        showRings = self.showRings,
+        showHalos = self.showHalos,
+        enableSounds = self.enableSounds
+    } )
+
+    SquadMenu.PrintF( "%s: writing %s", path, string.NiceSize( string.len( data ) ) )
+    file.Write( path, data )
+
+    if SquadMenu.mySquad then
+        SquadMenu:UpdateMembersHUD()
+    end
+end
+
+Config:Load()

--- a/lua/squad_menu/client/hud.lua
+++ b/lua/squad_menu/client/hud.lua
@@ -59,7 +59,6 @@ function SquadMenu:UpdateMembersHUD()
 
         s.childH = childH
         s.childOffset = childOffset
-
         s:SetSize( w, h )
 
         local position = math.Clamp( SquadMenu.GetMembersPosition(), 1, 9 )
@@ -115,8 +114,7 @@ end
 
 function SquadMenu:AddMemberToHUD( member )
     member.panel = vgui.Create( "Squad_MemberInfo", self.membersPanel )
-    member.panel:SetPlayer( member.id, member.name )
-    member.panel.squad = squad
+    member.panel:SetPlayer( member.id, member.name, squad )
 
     self.membersPanel:InvalidateLayout()
 end
@@ -168,6 +166,7 @@ local Clamp = math.Clamp
 local SetMaterial = surface.SetMaterial
 local DrawTexturedRect = surface.DrawTexturedRect
 local LocalPlayer = LocalPlayer
+local PID = SquadMenu.GetPlayerId
 
 do
     local Start3D2D = cam.Start3D2D
@@ -181,7 +180,7 @@ do
     SquadMenu.DrawRing = function( ply, flags )
         if flags == 1 then return end
         if ply == LocalPlayer() then return end
-        if not squad.membersById[ply:SteamID()] then return end
+        if not squad.membersById[PID( ply )] then return end
 
         local pos = ply:GetPos()
         local mult = Clamp( pos:DistToSqr( EyePos() ) / ringMaxDist, 0, 1 )
@@ -199,16 +198,16 @@ end
 
 ----------
 
-local AllPlayersBySteamID = SquadMenu.AllPlayersBySteamID
+local AllPlayersById = SquadMenu.AllPlayersById
 
 SquadMenu.DrawHalos = function()
     local origin = EyePos()
     local me = LocalPlayer()
-    local players = AllPlayersBySteamID()
+    local byId = AllPlayersById()
     local i, t, dist = 0, {}
 
     for _, member in ipairs( squad.members ) do
-        local ply = players[member.id]
+        local ply = byId[member.id]
 
         if ply and ply ~= me then
             dist = origin:DistToSqr( ply:EyePos() )
@@ -234,7 +233,7 @@ SquadMenu.HideTargetInfo = function()
     local ply = trace.Entity
     if not ply:IsPlayer() then return end
 
-    if squad.membersById[ply:SteamID()] and EyePos():DistToSqr( ply:EyePos() ) < nameDistance then
+    if squad.membersById[PID( ply )] and EyePos():DistToSqr( ply:EyePos() ) < nameDistance then
         return false
     end
 end
@@ -273,11 +272,11 @@ SquadMenu.DrawMemberTags = function()
 
     local origin = EyePos()
     local me = LocalPlayer()
-    local players = AllPlayersBySteamID()
+    local byId = AllPlayersById()
     local dist
 
     for _, member in ipairs( squad.members ) do
-        local ply = players[member.id]
+        local ply = byId[member.id]
 
         if ply and ply ~= me and not ply:IsDormant() then
             dist = origin:DistToSqr( ply:EyePos() )

--- a/lua/squad_menu/client/theme.lua
+++ b/lua/squad_menu/client/theme.lua
@@ -21,6 +21,7 @@ local colors = {
     entryText = Color( 255, 255, 255, 255 ),
 
     labelText = Color( 255, 255, 255, 255 ),
+    indicatorBackground = Color( 200, 0, 0, 255 )
 }
 
 local Theme = SquadMenu.Theme or {

--- a/lua/squad_menu/client/vgui/member_status.lua
+++ b/lua/squad_menu/client/vgui/member_status.lua
@@ -27,7 +27,8 @@ function PANEL:Init()
     self:SetPlayer()
 end
 
-function PANEL:SetPlayer( id, name )
+function PANEL:SetPlayer( id, name, squad )
+    self.squad = squad
     self.playerId = id
     self.validateTimer = 0
 
@@ -54,11 +55,11 @@ function PANEL:Think()
 
     self.validateTimer = RealTime() + 1
 
-    local ply = player.GetBySteamID( self.playerId )
+    local ply = SquadMenu.FindPlayerById( self.playerId )
 
     if ply then
         self.ply = ply
-        self.name = SquadMenu.ValidateString( ply:Nick(), "-", 20 )
+        self.name = SquadMenu.ValidateString( ply:Nick(), "", 20 )
         self.avatar:SetPlayer( ply, 64 )
     end
 end
@@ -66,8 +67,10 @@ end
 function PANEL:Paint( w, h )
     local split = h
 
-    SetColor( self.squad.color:Unpack() )
-    DrawRect( w - split, 0, split, h )
+    if self.squad then
+        SetColor( self.squad.color:Unpack() )
+        DrawRect( w - split, 0, split, h )
+    end
 
     SetColor( 0, 0, 0, 240 )
     SetMaterial( matGradient )

--- a/lua/squad_menu/client/vgui/squad_line.lua
+++ b/lua/squad_menu/client/vgui/squad_line.lua
@@ -63,7 +63,7 @@ function PANEL:Paint( w, h )
     surface.DrawRect( 0, 0, 4, h )
 
     draw.SimpleText( self.squad.name, "Trebuchet18", 48, 4 + DEFAULT_HEIGHT * 0.5, colors.buttonText, 0, 4 )
-    draw.SimpleText( self.squad.leaderName, "DefaultSmall", 48, 1 + DEFAULT_HEIGHT * 0.5, colors.buttonTextDisabled, 0, 3 )
+    draw.SimpleText( self.squad.leaderName or "<Server>", "DefaultSmall", 48, 1 + DEFAULT_HEIGHT * 0.5, colors.buttonTextDisabled, 0, 3 )
 end
 
 function PANEL:OnMousePressed( keyCode )
@@ -72,6 +72,8 @@ function PANEL:OnMousePressed( keyCode )
     end
 end
 
+--- Set the squad data.
+--- `squad` is a table that comes from `squad:GetBasicInfo`.
 function PANEL:SetSquad( squad )
     squad.color = Color( squad.r, squad.g, squad.b )
 
@@ -137,9 +139,11 @@ function PANEL:SetExpanded( expanded, scroll )
 
     self.membersScroll = membersScroll
 
-    local players = SquadMenu.AllPlayersBySteamID()
+    local byId = SquadMenu.AllPlayersById()
 
-    for _, member in ipairs( self.squad.members ) do
+    for _, m in ipairs( self.squad.members ) do
+        local id = m[1]
+
         local line = vgui.Create( "DPanel", membersScroll )
         line:SetBackgroundColor( colors.panelBackground )
         line:SetTall( memberHeight - 2 )
@@ -147,7 +151,7 @@ function PANEL:SetExpanded( expanded, scroll )
         line:DockMargin( 0, 0, 0, 2 )
 
         local name = vgui.Create( "DLabel", line )
-        name:SetText( member.name )
+        name:SetText( m[2] )
         name:Dock( FILL )
 
         local avatar = vgui.Create( "AvatarImage", line )
@@ -155,11 +159,13 @@ function PANEL:SetExpanded( expanded, scroll )
         avatar:Dock( LEFT )
         avatar:DockMargin( 4, 4, 4, 4 )
 
-        if players[member.id] then
-            avatar:SetPlayer( players[member.id], 64 )
+        if byId[id] then
+            avatar:SetPlayer( byId[id], 64 )
         end
 
-        if member.id == self.squad.leaderId then
+        if id == self.squad.leaderId then
+            line:SetZPos( -1 )
+
             local leaderIcon = vgui.Create( "DImage", line )
             leaderIcon:SetWide( 16 )
             leaderIcon:SetImage( "icon16/award_star_gold_3.png" )

--- a/lua/squad_menu/client/vgui/tabbed_frame.lua
+++ b/lua/squad_menu/client/vgui/tabbed_frame.lua
@@ -2,8 +2,6 @@ local L = SquadMenu.GetLanguageText
 local ApplyTheme = SquadMenu.Theme.Apply
 local colors = SquadMenu.Theme.colors
 
-colors.notifBackground = Color( 200, 0, 0, 255 )
-
 local TabButton = {}
 
 function TabButton:Init()
@@ -40,7 +38,7 @@ function TabButton:Paint( w, h )
         local x = w - size - 2
         local y = h - size - 2
 
-        draw.RoundedBox( size * 0.5, x, y, size, size, colors.notifBackground )
+        draw.RoundedBox( size * 0.5, x, y, size, size, colors.indicatorBackground )
         draw.SimpleText( self.notificationCount, "TargetIDSmall", x + size * 0.5, y + size * 0.5, colors.buttonText, 1, 1 )
     end
 end

--- a/lua/squad_menu/player.lua
+++ b/lua/squad_menu/player.lua
@@ -1,0 +1,5 @@
+local PlayerMeta = FindMetaTable( "Player" )
+
+function PlayerMeta:GetSquadID()
+    return self:GetNWInt( "squad_menu.id", -1 )
+end

--- a/lua/squad_menu/server/main.lua
+++ b/lua/squad_menu/server/main.lua
@@ -1,0 +1,188 @@
+resource.AddWorkshop( "3207278246" )
+
+SquadMenu.blockDamage = SquadMenu.blockDamage or {}
+SquadMenu.squads = SquadMenu.squads or {}
+SquadMenu.lastSquadId = SquadMenu.lastSquadId or 0
+
+--- Find a squad by it's ID.
+function SquadMenu:GetSquad( id )
+    return self.squads[id]
+end
+
+--- Find and remove a squad by it's ID.
+function SquadMenu:DeleteSquad( id )
+    local squad = self.squads[id]
+
+    if squad then
+        squad:Delete()
+    end
+end
+
+--- Remove a player id from join requests on all squads.
+function SquadMenu:CleanupRequests( id, dontSync )
+    for _, squad in pairs( self.squads ) do
+        if squad.requestsById[id] then
+            squad.requestsById[id] = nil
+
+            if not dontSync then
+                squad:SyncRequests()
+            end
+        end
+    end
+end
+
+-- Updates the player name everywhere it appears.
+function SquadMenu:UpdatePlayerName( ply )
+    if not IsValid( ply ) then return end
+
+    local id = self.GetPlayerId( ply )
+    local name = ply:Nick()
+
+    for _, squad in pairs( self.squads ) do
+        -- Update leader name
+        if squad.leaderId == id then
+            squad.leaderName = name
+        end
+
+        -- Update join request
+        if squad.requestsById[id] then
+            squad.requestsById[id] = name
+            squad:SyncRequests()
+        end
+
+        -- Update member name
+        if squad.membersById[id] then
+            squad.membersById[id] = name
+            squad:SyncWithMembers()
+        end
+    end
+end
+
+--- Create a new squad.
+function SquadMenu:CreateSquad()
+    local id = self.lastSquadId + 1
+    self.lastSquadId = id
+
+    self.squads[id] = setmetatable( {
+        id = id,
+        name = "",
+        icon = "",
+
+        enableRings = false,
+        friendlyFire = false,
+        isPublic = false,
+
+        r = 255,
+        g = 255,
+        b = 255,
+
+        -- Members key-value table. Do not modify directly,
+        -- instead use squad:AddMember/squad:RemoveMember.
+        --
+        -- Each key is a player id from SquadMenu.GetPlayerId,
+        -- and each value is the player name.
+        membersById = {},
+
+        -- Join Requests key-value table.
+        --
+        -- Each key is a player id from SquadMenu.GetPlayerId,
+        -- and each value is the player name.
+        requestsById = {}
+    }, self.Squad )
+
+    self.PrintF( "Created squad #%d", id )
+
+    return self.squads[id]
+end
+
+-- Callbacks on FCVAR_REPLICATED cvars don't work clientside so we need this
+cvars.AddChangeCallback( "squad_members_position", function()
+    SquadMenu.StartEvent( "squad_position_changed" )
+    net.Broadcast()
+end, "changed_squad_members_position" )
+
+--- Update player names on change
+gameevent.Listen( "player_changename" )
+hook.Add( "player_changename", "SquadMenu.UpdatePlayerName", function( data )
+    SquadMenu:UpdatePlayerName( Player( data.userid ) )
+end )
+
+--- Update player names on first spawn
+hook.Add( "PlayerInitialSpawn", "SquadMenu.UpdatePlayerName", function( ply )
+    SquadMenu:UpdatePlayerName( ply )
+end )
+
+-- On disconnect, remove join requests and this player from their squad, if they have one
+hook.Add( "PlayerDisconnected", "SquadMenu.PlayerCleanup", function( ply )
+    SquadMenu:CleanupRequests( PID( ply ) )
+
+    local squad = SquadMenu:GetSquad( ply:GetSquadID() )
+
+    if squad then
+        squad:RemoveMember( ply )
+    end
+end )
+
+--- Block damage between squad members
+local blockDamage = SquadMenu.blockDamage
+
+hook.Add( "PlayerShouldTakeDamage", "SquadMenu.BlockFriendlyFire", function( ply, attacker )
+    if not attacker.GetSquadID then return end
+
+    local id = ply:GetSquadID()
+
+    if id ~= -1 and ply ~= attacker and blockDamage[id] and id == attacker:GetSquadID() then
+        return false
+    end
+end )
+
+--- Chat commands and squad-only chat messages
+local prefixes = {}
+
+for _, prefix in ipairs( SquadMenu.CHAT_PREFIXES ) do
+    prefixes[prefix] = true
+end
+
+hook.Add( "PlayerSay", "SquadMenu.RemovePrefix", function( sender, text )
+    -- Check for commands to open the menu
+    if text[1] == "!" then
+        text = string.lower( string.Trim( text ) )
+
+        if text == "!squad" or text == "!party" then
+            SquadMenu.StartEvent( "open_menu" )
+            net.Send( sender )
+
+            return ""
+        end
+    end
+
+    -- Check if this is supposed to be a members-only message
+    local parts = string.Explode( " ", text, false )
+    if not parts[1] or not prefixes[parts[1]] then return end
+
+    local id = sender:GetSquadID()
+
+    if id == -1 then
+        sender:ChatPrint( "You're not in a squad." )
+        return ""
+    end
+
+    table.remove( parts, 1 )
+
+    text = table.concat( parts, " " )
+
+    if text:len() == 0 then
+        sender:ChatPrint( "Please type a message to send to your squad members." )
+        return ""
+    end
+
+    local members = SquadMenu:GetSquad( id ):GetActiveMembers()
+
+    SquadMenu.StartEvent( "members_chat", {
+        senderName = sender:Nick(),
+        text = text
+    } )
+    net.Send( members )
+
+    return ""
+end, HOOK_HIGH )

--- a/lua/squad_menu/server/squad.lua
+++ b/lua/squad_menu/server/squad.lua
@@ -1,109 +1,57 @@
 local IsValid = IsValid
-local blockDamage = SquadMenu.blockDamage or {}
+local PID = SquadMenu.GetPlayerId
+local FindByPID = SquadMenu.FindPlayerById
 
-SquadMenu.squads = SquadMenu.squads or {}
-SquadMenu.lastSquadId = SquadMenu.lastSquadId or 0
-SquadMenu.blockDamage = blockDamage
-
-hook.Add( "PlayerShouldTakeDamage", "SquadMenu.BlockFriendlyFire", function( ply, attacker )
-    if not attacker.GetSquadID then return end
-    local id = ply:GetSquadID()
-
-    if id ~= -1 and ply ~= attacker and blockDamage[id] and id == attacker:GetSquadID() then
-        return false
-    end
-end )
-
---- Find a squad by it's ID.
-function SquadMenu:GetSquad( id )
-    return self.squads[id]
-end
-
---- Find and remove a squad by it's ID.
-function SquadMenu:DeleteSquad( id )
-    if self.squads[id] then
-        self.squads[id] = nil
-        self.blockDamage[id] = nil
-
-        self.PrintF( "Deleted squad #%d", id )
-
-        self.StartEvent( "squad_deleted", { id = id } )
-        net.Broadcast()
-    end
-end
-
---- Check for and remove player from join requests on all squads
-function SquadMenu:CleanupRequests( steamId, dontSync )
-    for _, squad in pairs( self.squads ) do
-        if squad.requests[steamId] then
-            squad.requests[steamId] = nil
-
-            if not dontSync then
-                squad:SyncRequests()
-            end
-        end
-    end
-end
-
-local Squad = {}
-
+local Squad = SquadMenu.Squad or {}
+SquadMenu.Squad = Squad
 Squad.__index = Squad
 
---- Register a new squad.
-function SquadMenu:CreateSquad( leader )
-    local id = self.lastSquadId + 1
-    self.lastSquadId = id
+--- Set the leader of this squad. `ply` can either be
+--- a player entity, a ID string that came from `SquadMenu.GetPlayerId`,
+--- or `nil` if you want to unset the current squad leader.
+function Squad:SetLeader( ply, name )
+    if type( ply ) == "string" then
+        self.leaderId = ply -- this is a player ID
+        self.leaderName = name or "?"
 
-    self.squads[id] = setmetatable( {
-        id = id,
-        leader = leader,
+    elseif IsValid( ply ) then
+        self.leaderId = PID( ply )
+        self.leaderName = ply:Nick()
 
-        name = "",
-        icon = "",
+    else
+        self.leaderId = nil
+        self.leaderName = nil
 
-        enableRings = false,
-        friendlyFire = false,
-        isPublic = false,
+        SquadMenu.PrintF( "Removed leader from squad #%d", self.id )
+        return
+    end
 
-        r = 255,
-        g = 255,
-        b = 255,
-
-        members = {},
-        requests = {}
-    }, Squad )
-
-    self.PrintF( "Created squad #%d for %s", id, leader:SteamID() )
-
-    return self.squads[id]
+    SquadMenu.PrintF( "New leader for squad #%d: %s <%s>", self.id, self.leaderName, self.leaderId )
 end
 
---- Get a table containing details of this squad.
-function Squad:GetBasicInfo()
-    local members = {}
-    local count = 0
+--- Get a table containing a list of active squad members.
+--- Returns an array of player entities that are currently on the server.
+function Squad:GetActiveMembers()
+    local members, count = {}, 0
+    local byId = SquadMenu.AllPlayersById()
 
-    -- Take the chance to cleanup invalid members, if/when this somehow happens
-    for i = #self.members, 1, -1 do
-        local member = self.members[i]
-
-        if IsValid( member ) then
+    for id, _ in pairs( self.membersById ) do
+        if byId[id] then
             count = count + 1
-            members[count] = { id = member:SteamID(), name = member:Nick() }
-        else
-            table.remove( self.members, i )
+            members[count] = byId[id]
         end
     end
 
-    return {
+    return members, count
+end
+
+--- Get a ready-to-be-stringified table containing details from this squad.
+function Squad:GetBasicInfo()
+    local info = {
         id = self.id,
-        members = members,
-
-        leaderId = self.leader:SteamID(),
-        leaderName = self.leader:Nick(),
-
         name = self.name,
         icon = self.icon,
+        members = {},
 
         enableRings = self.enableRings,
         friendlyFire = self.friendlyFire,
@@ -113,6 +61,20 @@ function Squad:GetBasicInfo()
         g = self.g,
         b = self.b
     }
+
+    if self.leaderId then
+        info.leaderId = self.leaderId
+        info.leaderName = self.leaderName
+    end
+
+    local count = 0
+
+    for id, name in pairs( self.membersById ) do
+        count = count + 1
+        info.members[count] = { id, name }
+    end
+
+    return info
 end
 
 local ValidateString = SquadMenu.ValidateString
@@ -131,43 +93,69 @@ function Squad:SetBasicInfo( info )
     self.g = ValidateNumber( info.g, 255, 0, 255 )
     self.b = ValidateNumber( info.b, 255, 0, 255 )
 
-    blockDamage[self.id] = Either( self.friendlyFire, nil, true )
+    SquadMenu.blockDamage[self.id] = Either( self.friendlyFire, nil, true )
 end
 
 --- Send details and a list of members to all squad members.
-function Squad:SyncWithMembers()
-    if #self.members == 0 then return end
+--- You should never set `immediate` to `true` unless you know what you're doing.
+function Squad:SyncWithMembers( immediate )
+    if not immediate then
+        -- avoid spamming the networking system
+        timer.Remove( "SquadMenu.Sync" .. self.id )
+        timer.Create( "SquadMenu.Sync" .. self.id, 0.5, 1, function()
+            self:SyncWithMembers( true )
+        end )
+
+        return
+    end
+
+    local members, count = self:GetActiveMembers()
+    if count == 0 then return end
 
     local data = self:GetBasicInfo()
 
     SquadMenu.StartCommand( SquadMenu.SETUP_SQUAD )
     SquadMenu.WriteTable( data )
-    net.Send( self.members )
+    net.Send( members )
 end
 
 --- Send the requests list to the squad leader.
 function Squad:SyncRequests()
+    local leader = FindByPID( self.leaderId )
+    if not IsValid( leader ) then return end
+
     SquadMenu.StartCommand( SquadMenu.REQUESTS_LIST )
-    SquadMenu.WriteTable( self.requests )
-    net.Send( self.leader )
+    SquadMenu.WriteTable( self.requestsById )
+    net.Send( leader )
+end
+
+--- Turns `p` into a id and player entity depending on what `p` is.
+local function ParsePlayerArg( p )
+    if type( p ) == "string" then
+        return p, FindByPID( p )
+    end
+
+    return PID( p ), p
 end
 
 --- Add a player as a new member.
-function Squad:AddMember( ply, dontSync )
-    if ply:GetSquadID() == self.id then return end
+--- `p` can be a player id from `SquadMenu.GetPlayerId` or a player entity.
+function Squad:AddMember( p )
+    local id, ply = ParsePlayerArg( p )
+    if self.membersById[id] then return end
 
-    local count = #self.members
+    local count = table.Count( self.membersById )
     if count >= SquadMenu.GetMemberLimit() then return end
 
-    ply:SetNWInt( "squad_menu.id", self.id )
+    local name = id
 
-    self.members[count + 1] = ply
-
-    if not dontSync then
-        self:SyncWithMembers()
+    if IsValid( ply ) then
+        ply:SetNWInt( "squad_menu.id", self.id )
+        name = ply:Nick()
     end
 
-    local id = ply:SteamID()
+    self.membersById[id] = name
+    self:SyncWithMembers()
 
     -- We don't send the requests list to the squad leaders (2nd "true" parameter)
     -- because "player_joined_squad" will already tell them to remove
@@ -182,16 +170,22 @@ function Squad:AddMember( ply, dontSync )
 end
 
 --- Remove a player from this squad's members list.
-function Squad:RemoveMember( ply, reasonId )
-    local index = table.KeyFromValue( self.members, ply )
-    if not index then return end
+--- `ply` can be a player id from `SquadMenu.GetPlayerId` or a player entity.
+--- `reasonId` can be `nil` or one of the values from `SquadMenu.LEAVE_REASON_*`.
+function Squad:RemoveMember( p, reasonId )
+    local id, ply = ParsePlayerArg( p )
+    if not self.membersById[id] then return end
 
-    if ply == self.leader then
-        self:Disband()
+    if id == self.leaderId then
+        self:Delete()
         return
     end
 
-    table.remove( self.members, index )
+    self.membersById[id] = nil
+    self:SyncWithMembers()
+
+    if not IsValid( ply ) then return end
+
     ply:SetNWInt( "squad_menu.id", -1 )
 
     if reasonId ~= nil then
@@ -199,8 +193,6 @@ function Squad:RemoveMember( ply, reasonId )
         net.WriteUInt( reasonId, 3 )
         net.Send( ply )
     end
-
-    self:SyncWithMembers()
 end
 
 --- Add a player to the list of players that
@@ -211,59 +203,59 @@ function Squad:RequestToJoin( ply )
         return
     end
 
-    local id = ply:SteamID()
+    local plyId = PID( ply )
+    if self.requestsById[plyId] then return end
 
-    if self.requests[id] then return end
-
-    self.requests[id] = ply:Nick()
+    self.requestsById[plyId] = ply:Nick()
     self:SyncRequests()
 end
 
---- Accept all the join requests from a list of players' SteamIDs.
+--- Accept all the join requests from a list of player IDs.
 function Squad:AcceptRequests( ids )
     if not table.IsSequential( ids ) then return end
 
-    local memberLimit = SquadMenu.GetMemberLimit() - #self.members
-    local players = SquadMenu.AllPlayersBySteamID()
-    local count = 0
+    local limit = SquadMenu.GetMemberLimit()
+    local count = table.Count( self.membersById )
 
     for _, id in ipairs( ids ) do
-        if count < memberLimit and players[id] and self.requests[id] then
+        if count >= limit then
+            break
+
+        elseif self.requestsById[id] then
             count = count + 1
 
-            self.requests[id] = nil
-            self:AddMember( players[id], true ) -- add but don't sync yet
+            self.requestsById[id] = nil
+            self:AddMember( id )
         end
-    end
-
-    if count > 0 then
-        self:SyncWithMembers() -- sync now
     end
 end
 
 --- Remove all members from this squad and delete it.
-function Squad:Disband()
-    local count = 0
-    local recipients = {}
+function Squad:Delete()
+    timer.Remove( "SquadMenu.Sync" .. self.id )
 
-    -- Remove all members from the squad
-    for _, ply in ipairs( self.members ) do
-        if IsValid( ply ) then
-            ply:SetNWInt( "squad_menu.id", -1 )
-
-            count = count + 1
-            recipients[count] = ply
-        end
-    end
+    local members, count = self:GetActiveMembers()
 
     if count > 0 then
+        for _, ply in ipairs( members ) do
+            ply:SetNWInt( "squad_menu.id", -1 )
+        end
+
         SquadMenu.StartCommand( SquadMenu.LEAVE_SQUAD )
         net.WriteUInt( SquadMenu.LEAVE_REASON_DELETED, 3 )
-        net.Send( recipients )
+        net.Send( members )
     end
 
-    self.members = nil
-    self.requests = nil
+    self.membersById = nil
+    self.requestsById = nil
 
-    SquadMenu:DeleteSquad( self.id )
+    local id = self.id
+
+    SquadMenu.squads[id] = nil
+    SquadMenu.blockDamage[id] = nil
+
+    SquadMenu.PrintF( "Deleted squad #%d", id )
+
+    SquadMenu.StartEvent( "squad_deleted", { id = id } )
+    net.Broadcast()
 end


### PR DESCRIPTION
- More comments
- Better compatibility with lua autorefresh
- Use a dedicated function to turn a player entity into a identifier
- Use player IDs instead of player entities in the list of members/requests serverside
- Use `squad:GetActiveMembers()` to get player entities instead of storing them on `squad.members`
- Moved some functions from `sh_squad_menu.lua` to appropriate locations
- Moved client config code to a separate file
- Made `squad:SyncWithMembers()` handle anti-network-spam by itself
- Bots can now work with this addon when added manually by code