### PR TITLE
Add ignoreLimit parameter to AddMember function

### DIFF
--- a/lua/squad_menu/server/squad.lua
+++ b/lua/squad_menu/server/squad.lua
@@ -144,12 +144,12 @@ end
 
 --- Add a player as a new member.
 --- `p` can be a player id from `SquadMenu.GetPlayerId` or a player entity.
-function Squad:AddMember( p )
+function Squad:AddMember( p, ignoreLimit )
     local id, ply = ParsePlayerArg( p )
     if self.membersById[id] then return end
 
     local count = table.Count( self.membersById )
-    if count >= SquadMenu.GetMemberLimit() then return end
+    if not ignoreLimit and count >= SquadMenu.GetMemberLimit() then return end
 
     local name = id
 

--- a/lua/squad_menu/server/squad.lua
+++ b/lua/squad_menu/server/squad.lua
@@ -144,6 +144,7 @@ end
 
 --- Add a player as a new member.
 --- `p` can be a player id from `SquadMenu.GetPlayerId` or a player entity.
+--- `ignoreLimit` can be a boolean to ignore the member limit check, useful for external addons.
 function Squad:AddMember( p, ignoreLimit )
     local id, ply = ParsePlayerArg( p )
     if self.membersById[id] then return end


### PR DESCRIPTION
Allows external addons to bypass this limit check, for example my staff like using squads for events and we set peoples squads using starfall