### PR TITLE
Improve cooldown message for network commands

### DIFF
--- a/lua/squad_menu/server/network.lua
+++ b/lua/squad_menu/server/network.lua
@@ -162,7 +162,7 @@ net.Receive( "squad_menu.command", function( _, ply )
     local players = cooldowns[cmd].players
 
     if players[id] and players[id] > t then
-        SquadMenu.PrintF( "%s <%s> sent network commands too fast!", ply:Nick(), id )
+        SquadMenu.PrintF( "%s <%s> sent network command <%s> too fast!", ply:Nick(), id, cmd )
         return
     end
 


### PR DESCRIPTION
I've been seeing this semi frequently
<img width="418" height="466" alt="image" src="https://github.com/user-attachments/assets/9215b926-71ec-47b2-b958-e1e287f93d56" />
Adding the command would allow us to see what exactly is causing issues for people
Didn't test it but seems simple enough 