### PR TITLE
Reduce ping interval in squad menu

### DIFF
--- a/lua/squad_menu/server/network.lua
+++ b/lua/squad_menu/server/network.lua
@@ -146,7 +146,7 @@ local cooldowns = {
     [SquadMenu.LEAVE_SQUAD] = { interval = 1, players = {} },
     [SquadMenu.ACCEPT_REQUESTS] = { interval = 0.2, players = {} },
     [SquadMenu.KICK] = { interval = 0.1, players = {} },
-    [SquadMenu.PING] = { interval = 0.5, players = {} }
+    [SquadMenu.PING] = { interval = 0.1, players = {} }
 }
 
 net.Receive( "squad_menu.command", function( _, ply )


### PR DESCRIPTION
After https://github.com/StyledStrike/gmod-squad-menu/pull/10 ive seen net command 8 hitting a limit often, which makes sense as pinging every half a second is a little slow, this should help while still preventing abuse.

`[Squad Menu] blah sent network command <8> too fast!`