### PR TITLE
Fix compression fail error

### DIFF
--- a/lua/autorun/sh_squad_menu.lua
+++ b/lua/autorun/sh_squad_menu.lua
@@ -169,6 +169,13 @@ function SquadMenu.WriteTable( t, maxSize )
     end
 
     data = util.Compress( data )
+
+    if not data then
+        SquadMenu.PrintF( "Failed to write compressed JSON!" )
+        net.WriteUInt( 0, 16 )
+        return
+    end
+    
     len = #data
 
     if len > maxSize then


### PR DESCRIPTION
Fixes:
```
- lua/autorun/sh_squad_menu.lua:172: attempt to get length of local 'data' (a nil value)
1. WriteTable - lua/autorun/sh_squad_menu.lua:172
 2. DoClick - lua/squad_menu/client/menu.lua:266
  3. <unknown> - lua/vgui/dlabel.lua:253
```
For some reason sometimes it fails to compress
